### PR TITLE
Fix Issue #8 Composer RuntimeException, Set up PHPUnit, Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ composer.lock
 /app/config/defaultMailConfig.php
 /app/config/local/*
 .DS_Store
+/build/logs/*
+l4withsentry.sublime-workspace
+l4withsentry.sublime-project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php: 
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script:
+  - curl -s http://getcomposer.org/installer | php
+  - php composer.phar install --prefer-dist --no-interaction
+
+script: phpunit --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/app/tests/ExampleTest.php
+++ b/app/tests/ExampleTest.php
@@ -16,4 +16,10 @@ class ExampleTest extends TestCase {
 		$this->assertCount(1, $crawler->filter('h1:contains("Hello World!")'));
 	}
 
+	public function testUserCreateViewMake()
+    {
+        // Our first test!
+        $this->call('get', URL::action('UserController@create'));
+	}
+
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
 	"require": {
 		"laravel/framework": "4.0.*@dev",
-		"cartalyst/sentry": "2.0.*"
+		"cartalyst/sentry": "2.0.*",
+		"mockery/mockery": "dev-master@dev",
+		"phpunit/phpunit": "3.7.*"
 	},
 	"require-dev": {
 		"way/generators": "1.0.*@dev"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
 			"app/models",
 			"app/database/migrations",
 			"app/database/seeds",
-			"app/tests/TestCase.php",
-			"app/libraries"
+			"app/tests/TestCase.php"
 		],
 		"psr-0": {
 			"Authority": "app/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,9 @@
          stopOnFailure="false"
          syntaxCheck="false"
 >
+    <logging>
+        <log type="coverage-clover" target="./build/logs/clover.xml" />
+    </logging>
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./app/tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,9 @@
             <directory>./app/tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <blacklist>
+            <directory>./vendor/*</directory>
+        </blacklist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Fixes #8, Composer RuntimeException
Adds PHPUnit, Mockery dependencies to composer
Adds code coverage export option to PHPUnit xml
Adds folders to hold code coverage report on build
Adds a first example test of the UserController@create method.
Adds a working travis-ci config file for PHP 5.3, 5.4, 5.5: My fork is building here:
https://travis-ci.org/jcummins/L4withSentry
